### PR TITLE
Tooltip on hover with labeled nodes

### DIFF
--- a/src/NetworkChart.jsx
+++ b/src/NetworkChart.jsx
@@ -80,7 +80,7 @@ const Label = (props) => {
       {
         style =>
         <text
-          x={style.x} y={style.y}
+          x={style.x} y={style.y} style={{pointerEvents:"none"}}
           alignmentBaseline="middle" textAnchor={textAnchor}
           fill={props.fill}>
             {props.labelText}


### PR DESCRIPTION
Fixed the issue where tooltip was not displayed on hover when the node has an overlay text.

![screen shot 2017-10-05 at 3 58 33 pm](https://user-images.githubusercontent.com/25045998/31249721-5ca5cd16-a9e6-11e7-9a3d-c86de5cf0c1d.png)

@sanjaypojo @AlmahaAlmalki #16 